### PR TITLE
GL-2784-Only-One-Sizing-Sampler-Pack 

### DIFF
--- a/server/api/carts/cart_controller.js
+++ b/server/api/carts/cart_controller.js
@@ -79,6 +79,9 @@ export default {
     const { body } = req;
     try {
       const cart = await cart_services.add_to_cart_carts_s(body);
+      if (body.cartItems.length === cart.cartItems.length) {
+        return res.status(500).send({ message: "Can only buy a single Sizing Sampler per order" });
+      }
       if (cart) {
         return res.status(200).send(cart);
       }

--- a/server/api/carts/cart_helpers.js
+++ b/server/api/carts/cart_helpers.js
@@ -63,6 +63,14 @@ export const areCartItemsEqual = (item1, item2) => {
 export const updateCartItems = (cartItems, cart_item) => {
   let found = false;
 
+  // Check if the cart already contains 'Supreme Gloves V2 Sizing Sampler Pack'
+  const alreadyContainsSpecificProduct = cartItems.some(x => x.name.includes("Sizing Sampler Pack"));
+
+  // If adding 'Supreme Gloves V2 Sizing Sampler Pack' and it already exists in the cart, return cartItems as is
+  if (cart_item.name === "Supreme Gloves V2 Sizing Sampler Pack" && alreadyContainsSpecificProduct) {
+    return cartItems;
+  }
+
   const updatedItems = cartItems.map(x => {
     if (areCartItemsEqual(x, cart_item)) {
       found = true;


### PR DESCRIPTION
# Pull Request Tasks and Guidelines

### Description

- Added logic to only allow a single sampler pack to be added

---

### Author Checklist:

- [ ] Jira issue relating to changes [GL-2784](https://glowleds.atlassian.net/browse/GL-2784)
